### PR TITLE
Issue#50

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImpl.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImpl.java
@@ -4,7 +4,6 @@ import com.github.thorbenkuck.netcom2.annotations.APILevel;
 import com.github.thorbenkuck.netcom2.annotations.remoteObjects.IgnoreRemoteExceptions;
 import com.github.thorbenkuck.netcom2.annotations.remoteObjects.RegistrationOverrideProhibited;
 import com.github.thorbenkuck.netcom2.exceptions.RemoteObjectNotRegisteredException;
-import com.github.thorbenkuck.netcom2.exceptions.RemoteRequestException;
 import com.github.thorbenkuck.netcom2.interfaces.RemoteObjectRegistration;
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
 import com.github.thorbenkuck.netcom2.network.shared.Session;
@@ -23,6 +22,21 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 
 	private final Map<Class<?>, Object> mapping = new HashMap<>();
 	private final Logging logging = Logging.unified();
+	private static final Map<Class<?>, Class<?>> PRIMITIVE_MAPPING;
+
+	static {
+		Map<Class<?>, Class<?>> primitives = new HashMap<>();
+		primitives.put(int.class, Integer.class);
+		primitives.put(double.class, Double.class);
+		primitives.put(long.class, Long.class);
+		primitives.put(short.class, Short.class);
+		primitives.put(float.class, Float.class);
+		primitives.put(char.class, Character.class);
+		primitives.put(boolean.class, Boolean.class);
+		primitives.put(byte.class, Byte.class);
+
+		PRIMITIVE_MAPPING = Collections.unmodifiableMap(primitives);
+	}
 
 	@APILevel
 	RemoteObjectRegistrationImpl() {
@@ -51,7 +65,8 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 		List<Object> parameters = new ArrayList<>();
 
 		for (Class parameterClass : method.getParameterTypes()) {
-			Object o = get(arguments, parameterClass);
+			Class casedParameter = convertPrimitiveTypes(parameterClass);
+			Object o = get(arguments, casedParameter);
 			parameters.add(o);
 		}
 
@@ -60,7 +75,7 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 
 	private Object get(List<Object> array, Class clazz) {
 		for (Object object : array) {
-			if (object.getClass().equals(clazz)) {
+			if (convertPrimitiveTypes(object.getClass()).equals(clazz)) {
 				return object;
 			}
 		}
@@ -128,6 +143,22 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 		return false;
 	}
 
+	/**
+	 * This method converts primitive types to their wrapper types.
+	 *
+	 * Because of the way, the java.io serialization runs, primitive classes are changed to their wrapper types.
+	 * This mean, that remote-methods, that declare a primitive type, will never be called, because the arguments do not
+	 * match.
+	 *
+	 * This method was introduced because of the Issue#50
+	 *
+	 * @param input the potential primitive type
+	 * @return the Wrapper type, or the type that provided if not primitive.
+	 */
+	private Class<?> convertPrimitiveTypes(Class<?> input) {
+		return PRIMITIVE_MAPPING.getOrDefault(input, input);
+	}
+
 	private boolean parameterTypesEqual(Method method, Object[] args) {
 		Class<?>[] declaredParameterTypes = method.getParameterTypes();
 		if (args == null) {
@@ -137,7 +168,16 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 			return false;
 		}
 		for (int i = 0; i < args.length; i++) {
-			if (! declaredParameterTypes[i].equals(args[i].getClass())
+			Class<?> declaredType = convertPrimitiveTypes(declaredParameterTypes[i]);
+			Class<?> argumentType = convertPrimitiveTypes(args[i].getClass());
+			// This check, checks for Session
+			// or Connection types as well as for
+			// the declared type.  This means,
+			// if you would be able to, you could inject
+			// a Session or Connection into an Method-Declaration
+			// and still be running this RMI API.
+			// This is not relevant for Java.
+			if (! declaredType.equals(argumentType)
 					|| declaredParameterTypes[i].equals(Session.class)
 					|| declaredParameterTypes[i].equals(Connection.class)) {
 				return false;

--- a/src/test/java/com/github/thorbenkuck/netcom2/integration/rmi/PrimitiveRemoteTestInterface.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/integration/rmi/PrimitiveRemoteTestInterface.java
@@ -1,0 +1,7 @@
+package com.github.thorbenkuck.netcom2.integration.rmi;
+
+public interface PrimitiveRemoteTestInterface {
+
+	String get(int i);
+
+}

--- a/src/test/java/com/github/thorbenkuck/netcom2/integration/rmi/RMIClient.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/integration/rmi/RMIClient.java
@@ -65,7 +65,8 @@ public class RMIClient implements Runnable {
 
 		test = clientStart.getRemoteObjectFactory().create(RemoteTestInterface.class);
 
-		System.out.println(test.getHelloWorld());
+		PrimitiveRemoteTestInterface primitiveRemoteTestInterface = clientStart.getRemoteObject(PrimitiveRemoteTestInterface.class);
+		System.out.println(primitiveRemoteTestInterface.get(11));
 	}
 
 	private void scheduleReconnect() {

--- a/src/test/java/com/github/thorbenkuck/netcom2/integration/rmi/RMIServer.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/integration/rmi/RMIServer.java
@@ -7,7 +7,7 @@ import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
 public class RMIServer implements Runnable {
 
-	private ServerStart serverStart = ServerStart.at(666);
+	private ServerStart serverStart = ServerStart.at(4444);
 
 	public static void main(String[] args) {
 		new RMIServer().run();
@@ -16,27 +16,28 @@ public class RMIServer implements Runnable {
 	@Override
 	public void run() {
 		serverStart.remoteObjects().register(new RemoteTest(), RemoteTestInterface.class);
+		serverStart.remoteObjects().register(new PrimitiveRemoteTest(), PrimitiveRemoteTestInterface.class);
 		try {
 			serverStart.launch();
-			NetCom2Utils.runLater(() -> {
-				try {
-					serverStart.acceptAllNextClients();
-				} catch (ClientConnectionFailedException e) {
-					e.printStackTrace();
-				}
-			});
-		} catch (StartFailedException e) {
+			serverStart.acceptAllNextClients();
+		} catch (StartFailedException | ClientConnectionFailedException e) {
 			e.printStackTrace();
 		}
-
-		System.out.println();
 	}
 
 	private class RemoteTest implements RemoteTestInterface {
 
 		@Override
 		public String getHelloWorld() {
-			return "Fick dich, frag doch wen anders!";
+			return "Go ask someone else!";
+		}
+	}
+
+	private class PrimitiveRemoteTest implements PrimitiveRemoteTestInterface {
+
+		@Override
+		public String get(final int i) {
+			return "sqr(" + String.valueOf(i * i) + ") = " + i;
 		}
 	}
 }


### PR DESCRIPTION
Introduced a new Map, which defines the Wrapper-Classes to replace the primitive types.

This is not as optimal as possible, but it is the only way, since the java serialization changes the primitive types to the wrapper parts.

This was testet in an integration-test (com.github.thorbenkuck.netcom2.integration.rmi) with a PrimitiveRemoteTestInterface, which expects an int parameter. prior to change, this failed. Now it succeds.