### PR TITLE
Test DistributorImpl, clean up DistributorImpl, JavaDoc

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/network/server/Distributor.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/server/Distributor.java
@@ -6,17 +6,62 @@ import java.util.function.Predicate;
 
 public interface Distributor {
 
+	/**
+	 * Sends the specified object to all clients satisfying <b>all</b> given predicates,
+	 * by using their DefaultConnection.
+	 *
+	 * @param o The object to send
+	 * @param predicates The predicates to filter by
+	 */
 	void toSpecific(final Object o, final Predicate<Session>... predicates);
 
+	/**
+	 * Sends the specified object to <b>all</b> clients, using their DefaultConnection.
+	 *
+	 * @param o The object to send
+	 */
 	void toAll(final Object o);
 
+	/**
+	 * Sends the specified object to all clients that do <b>not satisfy any</b> of the given predicates.
+	 * The sending happens using the clients' DefaultConnection.
+	 *
+	 * @param o The object to send
+	 * @param predicates The predicates to filter by
+	 */
 	void toAllExcept(final Object o, final Predicate<Session>... predicates);
 
+	/**
+	 * Sends the given object to all clients that are identified.
+	 * The clients' DefaultConnection will be used.
+	 *
+	 * @param o The object to send
+	 */
 	void toAllIdentified(final Object o);
 
+	/**
+	 * Sends the given object to all clients that are identified <b>and</b> satisfy all predicates.
+	 * The clients' DefaultConnection will be used.
+	 *
+	 * @param o The object to send
+	 * @param predicates The predicates to filter by
+	 */
 	void toAllIdentified(final Object o, final Predicate<Session>... predicates);
 
+	/**
+	 * Sends the given object to all clients that are registered.
+	 * The clients' DefaultConnection will be used.
+	 *
+	 * @param o The object to send
+	 */
 	void toRegistered(final Object o);
 
+	/**
+	 * Sends the given object to all clients that are registered <b>and</b> satisfy all predicates.
+	 * The clients' DefaultConnection will be used.
+	 *
+	 * @param o The object to send
+	 * @param predicates The predicates to filter by
+	 */
 	void toRegistered(final Object o, final Predicate<Session>... predicates);
 }

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/server/DistributorImplTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/server/DistributorImplTest.java
@@ -1,15 +1,280 @@
 package com.github.thorbenkuck.netcom2.network.server;
 
+import com.github.thorbenkuck.netcom2.network.shared.Session;
+import com.github.thorbenkuck.netcom2.network.shared.comm.model.CachePush;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+
 public class DistributorImplTest {
-	@Test
-	public void getDistributorRegistration() throws Exception {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void toSpecificObjectNull() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+
+		//Act
+		distributor.toSpecific(null, s -> s.equals(session2));
+
+		//Assert
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void toSpecificPredicatesEmpty() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toSpecific(objectToSend, (List<Predicate<Session>>)null);
+
+		//Assert
 	}
 
 	@Test
-	public void toSpecific() throws Exception {
+	public void toSpecificMatchesOne() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toSpecific(objectToSend, s -> s.equals(session2));
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
 	}
+
+	@Test
+	public void toSpecificMatchesMultiple() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toSpecific(objectToSend, s -> s.equals(session2) || s.equals(session3));
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toSpecificMatchesOneMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(true);
+		when(session3.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toSpecific(objectToSend, s -> s.equals(session2), Session::isIdentified);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toSpecificMatchesNone() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(false);
+		when(session3.isIdentified()).thenReturn(false);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toSpecific(objectToSend, Session::isIdentified);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2, never()).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
+	}
+
+
+
+
+
+	@Test(expected = IllegalArgumentException.class)
+	public void toSpecificListObjectNull() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		List<Predicate<Session>> predicates = Collections.singletonList(s -> s.equals(session2));
+
+		//Act
+		distributor.toSpecific(null, predicates);
+
+		//Assert
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void toSpecificArrayPredicatesEmpty() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toSpecific(objectToSend, (Predicate<Session>[])null);
+
+		//Assert
+	}
+
+	@Test
+	public void toSpecificListMatchesOne() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.singletonList(s -> s.equals(session2));
+
+		//Act
+		distributor.toSpecific(objectToSend, predicates);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toSpecificListMatchesMultiple() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.singletonList(s -> s.equals(session2) || s.equals(session3));
+
+		//Act
+		distributor.toSpecific(objectToSend, predicates);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toSpecificListMatchesOneMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(true);
+		when(session3.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Arrays.asList(s -> s.equals(session2), Session::isIdentified);
+
+		//Act
+		distributor.toSpecific(objectToSend, predicates);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toSpecificListMatchesNone() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(false);
+		when(session3.isIdentified()).thenReturn(false);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.singletonList(Session::isIdentified);
+
+		//Act
+		distributor.toSpecific(objectToSend, predicates);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2, never()).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
+	}
+
+
+
 
 	@Test
 	public void toSpecificList() throws Exception {
@@ -17,34 +282,365 @@ public class DistributorImplTest {
 
 	@Test
 	public void toAll() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toAll(objectToSend);
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
 	}
 
 	@Test
 	public void toAllExcept() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toAllExcept(objectToSend, s -> s.equals(session2));
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2, never()).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toAllExceptNoPredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toAllExcept(objectToSend);
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
+	}
+
+	@Test
+	public void toAllExceptMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(false);
+		when(session3.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toAllExcept(objectToSend, s -> s.equals(session2), Session::isIdentified);
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2, never()).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
 	}
 
 	@Test
 	public void toAllExceptList() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.singletonList(s -> s.equals(session2));
+
+		//Act
+		distributor.toAllExcept(objectToSend, predicates);
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2, never()).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
 	}
 
 	@Test
-	public void toAllIdentified() throws Exception {
+	public void toAllExceptListNoPredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.emptyList();
+
+		//Act
+		distributor.toAllExcept(objectToSend, predicates);
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
 	}
 
 	@Test
-	public void toAllIdentified1() throws Exception {
+	public void toAllExceptListMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(false);
+		when(session3.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Arrays.asList(s -> s.equals(session2), Session::isIdentified);
+
+		//Act
+		distributor.toAllExcept(objectToSend, predicates);
+
+		//Assert
+		verify(session1).send(eq(objectToSend));
+		verify(session2, never()).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
 	}
 
 	@Test
-	public void toRegistered() throws Exception {
+	public void toAllIdentifiedMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(true);
+		when(session3.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toAllIdentified(objectToSend, s -> s.equals(session2), Session::isIdentified);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3, never()).send(eq(objectToSend));
 	}
 
 	@Test
-	public void toRegistered1() throws Exception {
+	public void toAllIdentifiedNoPredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(true);
+		when(session3.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session1, session2, session3));
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toAllIdentified(objectToSend);
+
+		//Assert
+		verify(session1, never()).send(eq(objectToSend));
+		verify(session2).send(eq(objectToSend));
+		verify(session3).send(eq(objectToSend));
 	}
 
 	@Test
-	public void toRegisteredList() throws Exception {
+	public void toRegisteredOnePredicate() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		Session session4 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session4));
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		when(distributorRegistration.getRegistered(ObjectToSend.class)).thenReturn(Arrays.asList(session1, session2, session3));
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toRegistered(objectToSend, s -> s.equals(session2));
+
+		//Assert
+		verify(session1, never()).send(isA(CachePush.class));
+		verify(session2).send(isA(CachePush.class));
+		verify(session3, never()).send(isA(CachePush.class));
+		verify(session4, never()).send(isA(CachePush.class));
+	}
+
+	@Test
+	public void toRegisteredMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		Session session4 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(true);
+		when(session3.isIdentified()).thenReturn(false);
+		when(session4.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session4));
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		when(distributorRegistration.getRegistered(ObjectToSend.class)).thenReturn(Arrays.asList(session1, session2, session3));
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toRegistered(objectToSend, s -> s.equals(session2), Session::isIdentified);
+
+		//Assert
+		verify(session1, never()).send(isA(CachePush.class));
+		verify(session2).send(isA(CachePush.class));
+		verify(session3, never()).send(isA(CachePush.class));
+		verify(session4, never()).send(isA(CachePush.class));
+	}
+
+	@Test
+	public void toRegisteredNoPredicate() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		Session session4 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session4));
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		when(distributorRegistration.getRegistered(ObjectToSend.class)).thenReturn(Arrays.asList(session1, session2, session3));
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		ObjectToSend objectToSend = new ObjectToSend();
+
+		//Act
+		distributor.toRegistered(objectToSend);
+
+		//Assert
+		verify(session1).send(isA(CachePush.class));
+		verify(session2).send(isA(CachePush.class));
+		verify(session3).send(isA(CachePush.class));
+		verify(session4, never()).send(isA(CachePush.class));
+	}
+
+	@Test
+	public void toRegisteredListOnePredicate() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		Session session4 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session4));
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		when(distributorRegistration.getRegistered(ObjectToSend.class)).thenReturn(Arrays.asList(session1, session2, session3));
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.singletonList(s -> s.equals(session2));
+
+		//Act
+		distributor.toRegistered(objectToSend, predicates);
+
+		//Assert
+		verify(session1, never()).send(isA(CachePush.class));
+		verify(session2).send(isA(CachePush.class));
+		verify(session3, never()).send(isA(CachePush.class));
+		verify(session4, never()).send(isA(CachePush.class));
+	}
+
+	@Test
+	public void toRegisteredListMultiplePredicates() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		Session session4 = mock(Session.class);
+		when(session1.isIdentified()).thenReturn(false);
+		when(session2.isIdentified()).thenReturn(true);
+		when(session3.isIdentified()).thenReturn(false);
+		when(session4.isIdentified()).thenReturn(true);
+		ClientList clientList = mock(ClientList.class);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session4));
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		when(distributorRegistration.getRegistered(ObjectToSend.class)).thenReturn(Arrays.asList(session1, session2, session3));
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Arrays.asList(s -> s.equals(session2), Session::isIdentified);
+
+		//Act
+		distributor.toRegistered(objectToSend, predicates);
+
+		//Assert
+		verify(session1, never()).send(isA(CachePush.class));
+		verify(session2).send(isA(CachePush.class));
+		verify(session3, never()).send(isA(CachePush.class));
+		verify(session4, never()).send(isA(CachePush.class));
+	}
+
+	@Test
+	public void toRegisteredListNoPredicate() throws Exception {
+		//Arrange
+		Session session1 = mock(Session.class);
+		Session session2 = mock(Session.class);
+		Session session3 = mock(Session.class);
+		Session session4 = mock(Session.class);
+		ClientList clientList = mock(ClientList.class);
+		when(clientList.sessionStream()).thenReturn(Stream.of(session4));
+		DistributorRegistration distributorRegistration = mock(DistributorRegistration.class);
+		when(distributorRegistration.getRegistered(ObjectToSend.class)).thenReturn(Arrays.asList(session1, session2, session3));
+		DistributorImpl distributor = new DistributorImpl(clientList, distributorRegistration);
+		ObjectToSend objectToSend = new ObjectToSend();
+		List<Predicate<Session>> predicates = Collections.emptyList();
+
+		//Act
+		distributor.toRegistered(objectToSend, predicates);
+
+		//Assert
+		verify(session1).send(isA(CachePush.class));
+		verify(session2).send(isA(CachePush.class));
+		verify(session3).send(isA(CachePush.class));
+		verify(session4, never()).send(isA(CachePush.class));
+	}
+
+	private class ObjectToSend {
+
 	}
 
 }


### PR DESCRIPTION
As specified in the title, test cases for all methods in DistributorImpl were added.

DistributorImpl was cleaned up because the implementation used to have repeated code in its methods. For all but one method where it was not possible (in a nice way), the methods now use a three step structure:

1. Obtaining the Sessions
2. Filtering the Sessions
3. Sending the specified object to the filtered Sessions

JavaDoc was added to all methods in the Distributor interface. The general interface description was left empty since I was unsure what one should write.