### PR TITLE
Test JavaSerializationAdapter, add Null-Check

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -4,6 +4,6 @@
     <option name="PER_PROJECT_SETTINGS">
       <value />
     </option>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (1)" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </component>
 </project>

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/JavaSerializationAdapter.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/JavaSerializationAdapter.java
@@ -3,6 +3,7 @@ package com.github.thorbenkuck.netcom2.network.shared.clients;
 import com.github.thorbenkuck.netcom2.annotations.Asynchronous;
 import com.github.thorbenkuck.netcom2.exceptions.SerializationFailedException;
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
+import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -16,6 +17,7 @@ public class JavaSerializationAdapter implements SerializationAdapter<Object, St
 	@Asynchronous
 	@Override
 	public String get(final Object o) throws SerializationFailedException {
+		NetCom2Utils.parameterNotNull(o);
 		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		ObjectOutputStream oos = null;
 		try {

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/JavaSerializationAdapterTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/JavaSerializationAdapterTest.java
@@ -35,7 +35,7 @@ public class JavaSerializationAdapterTest {
 		String serializedObject = adapter.get(object);
 
 		// Assert
-		assertTrue(serializedObject.length() % 4 == 0);
+		assertEquals(serializedObject.length() % 4, 0);
 		assertTrue(testBase64.test(serializedObject));
 	}
 
@@ -61,7 +61,7 @@ public class JavaSerializationAdapterTest {
 		SerializableClass object = null;
 
 		// Act
-		String serializedObject = adapter.get(object);
+		adapter.get(object);
 
 		// Assert
 	}

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/JavaSerializationAdapterTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/JavaSerializationAdapterTest.java
@@ -1,18 +1,73 @@
 package com.github.thorbenkuck.netcom2.network.shared.clients;
 
+import com.github.thorbenkuck.netcom2.exceptions.SerializationFailedException;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class JavaSerializationAdapterTest {
-	@Test
-	public void get() throws Exception {
+
+	@Test(expected = SerializationFailedException.class)
+	public void getNotSerializable() throws Exception {
 		// Arrange
+		JavaSerializationAdapter adapter = new JavaSerializationAdapter();
+		NotSerializableObject object = new NotSerializableObject();
 
 		// Act
+		adapter.get(object);
 
 		// Assert
-		fail();
+	}
+
+	@Test
+	public void getIsBase64() throws Exception {
+		// Arrange
+		JavaSerializationAdapter adapter = new JavaSerializationAdapter();
+		SerializableClass object = new SerializableClass("This is a test string!");
+		Pattern pattern = Pattern.compile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$");
+		Predicate<String> testBase64 = pattern.asPredicate();
+
+		// Act
+		String serializedObject = adapter.get(object);
+
+		// Assert
+		assertTrue(serializedObject.length() % 4 == 0);
+		assertTrue(testBase64.test(serializedObject));
+	}
+
+	@Test
+	public void getSerializable() throws Exception {
+		// Arrange
+		JavaSerializationAdapter adapter = new JavaSerializationAdapter();
+		JavaDeSerializationAdapter deSerializationAdapter = new JavaDeSerializationAdapter();
+		SerializableClass object = new SerializableClass("This is a test string!");
+
+		// Act
+		String serializedObject = adapter.get(object);
+		Object deserializedObject = deSerializationAdapter.get(serializedObject);
+
+		// Assert
+		assertEquals(object, deserializedObject);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getNull() throws Exception {
+		// Arrange
+		JavaSerializationAdapter adapter = new JavaSerializationAdapter();
+		SerializableClass object = null;
+
+		// Act
+		String serializedObject = adapter.get(object);
+
+		// Assert
+	}
+
+	private class NotSerializableObject {
+
 	}
 
 }

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/SerializableClass.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/SerializableClass.java
@@ -1,0 +1,28 @@
+package com.github.thorbenkuck.netcom2.network.shared.clients;
+
+import java.io.Serializable;
+
+public class SerializableClass implements Serializable {
+
+	private String aString;
+
+	public SerializableClass(String aString) {
+		this.aString = aString;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		SerializableClass that = (SerializableClass) o;
+
+		return aString != null ? aString.equals(that.aString) : that.aString == null;
+	}
+
+	@Override
+	public int hashCode() {
+		return aString != null ? aString.hashCode() : 0;
+	}
+
+}


### PR DESCRIPTION
JavaSerializationAdapter was written. While writing the test, I found out that it is allowed to serialize null, but not deserialize it.
I thus added a null-check in the adapter.