### PR TITLE
Test JavaDeSerializationAdapter

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingSerializationAdapter.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingSerializationAdapter.java
@@ -3,6 +3,7 @@ package com.github.thorbenkuck.netcom2.network.shared.clients;
 import com.github.thorbenkuck.netcom2.annotations.Asynchronous;
 import com.github.thorbenkuck.netcom2.exceptions.SerializationFailedException;
 import com.github.thorbenkuck.netcom2.network.shared.comm.model.Ping;
+import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
 public class PingSerializationAdapter implements SerializationAdapter<Object, String> {
 	private String serializePing(final Ping o) {
@@ -12,6 +13,7 @@ public class PingSerializationAdapter implements SerializationAdapter<Object, St
 	@Asynchronous
 	@Override
 	public String get(final Object o) throws SerializationFailedException {
+		NetCom2Utils.parameterNotNull(o);
 		if (o.getClass().equals(Ping.class)) {
 			return serializePing((Ping) o);
 		}

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingSerializationAdapterTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingSerializationAdapterTest.java
@@ -1,18 +1,37 @@
 package com.github.thorbenkuck.netcom2.network.shared.clients;
 
+import com.github.thorbenkuck.netcom2.network.shared.comm.model.Ping;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import static com.github.thorbenkuck.netcom2.TestUtils.UUID_SEED_1;
+import static org.junit.Assert.assertEquals;
 
 public class PingSerializationAdapterTest {
-	@Test
-	public void get() throws Exception {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getNull() throws Exception {
 		// Arrange
+		PingSerializationAdapter adapter = new PingSerializationAdapter();
+		Ping nullPing = null;
 
 		// Act
+		adapter.get(nullPing);
 
 		// Assert
-		fail();
+	}
+
+	@Test
+	public void getPing() throws Exception {
+		// Arrange
+		PingSerializationAdapter adapter = new PingSerializationAdapter();
+		ClientID clientID = ClientID.fromString(UUID_SEED_1);
+		Ping nullPing = new Ping(clientID);
+
+		// Act
+		String serializedPing = adapter.get(nullPing);
+
+		// Assert
+		assertEquals("Ping|"+clientID, serializedPing);
 	}
 
 }


### PR DESCRIPTION
JavaDeSerializationAdapter was written. While writing the test, I found out that it is allowed to serialize null, but not deserialize it.
I thus added a null-check in the adapter.