### PR TITLE
Test PingDeSerializationAdapter, add null-check

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingDeSerializationAdapter.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingDeSerializationAdapter.java
@@ -3,6 +3,7 @@ package com.github.thorbenkuck.netcom2.network.shared.clients;
 import com.github.thorbenkuck.netcom2.annotations.Asynchronous;
 import com.github.thorbenkuck.netcom2.exceptions.DeSerializationFailedException;
 import com.github.thorbenkuck.netcom2.network.shared.comm.model.Ping;
+import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
 public class PingDeSerializationAdapter implements DeSerializationAdapter<String, Object> {
 	private Object deSerializePing(final String s) {
@@ -12,6 +13,7 @@ public class PingDeSerializationAdapter implements DeSerializationAdapter<String
 	@Asynchronous
 	@Override
 	public Object get(final String s) throws DeSerializationFailedException {
+		NetCom2Utils.parameterNotNull(s);
 		if (s.startsWith("Ping")) {
 			return deSerializePing(s);
 		}

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingDeSerializationAdapterTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/PingDeSerializationAdapterTest.java
@@ -1,18 +1,49 @@
 package com.github.thorbenkuck.netcom2.network.shared.clients;
 
+import com.github.thorbenkuck.netcom2.exceptions.DeSerializationFailedException;
+import com.github.thorbenkuck.netcom2.network.shared.comm.model.Ping;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import static com.github.thorbenkuck.netcom2.TestUtils.UUID_SEED_1;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PingDeSerializationAdapterTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void getNull() throws Exception {
+		// Arrange
+		PingDeSerializationAdapter adapter = new PingDeSerializationAdapter();
+
+		// Act
+		adapter.get(null);
+
+		// Assert
+	}
+
+	@Test(expected = DeSerializationFailedException.class)
+	public void getNonPingString() throws Exception {
+		// Arrange
+		PingDeSerializationAdapter adapter = new PingDeSerializationAdapter();
+		String string = "somestring|" + UUID_SEED_1;
+
+		// Act
+		adapter.get(string);
+
+		// Assert
+	}
+
 	@Test
 	public void get() throws Exception {
 		// Arrange
+		PingDeSerializationAdapter adapter = new PingDeSerializationAdapter();
+		String string = "Ping|" + UUID_SEED_1;
 
 		// Act
+		Object returnedObject = adapter.get(string);
 
 		// Assert
-		fail();
+		assertThat(returnedObject, instanceOf(Ping.class));
 	}
 
 }


### PR DESCRIPTION
This commit tests PingDeSerializationAdapter.
While writing the test, I noticed that passing a null value to the get
method causes an NPE.
I thus added a check for null.