### PR TITLE
#27 default sending serivce test

### DIFF
--- a/NetCom2.iml
+++ b/NetCom2.iml
@@ -10,7 +10,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: com.github.thorbenkuck:Keller:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-all:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Maven: org.mockito:mockito-core:2.15.0" level="project" />

--- a/src/main/java/com/github/thorbenkuck/netcom2/exceptions/SetupListenerException.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/exceptions/SetupListenerException.java
@@ -1,0 +1,31 @@
+package com.github.thorbenkuck.netcom2.exceptions;
+
+public class SetupListenerException extends NetComRuntimeException {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param message
+	 */
+	public SetupListenerException(final String message) {
+		super(message);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param throwable
+	 */
+	public SetupListenerException(final Throwable throwable) {
+		super(throwable);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param message
+	 * @param throwable
+	 */
+	public SetupListenerException(final String message, final Throwable throwable) {
+		super(message, throwable);
+	}
+}

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/interfaces/SendingService.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/interfaces/SendingService.java
@@ -29,6 +29,8 @@ public interface SendingService extends Runnable, SoftStoppable {
 	/**
 	 * Sets up this SendingService.
 	 *
+	 * This means, internal dependencies will be resolved and this SendingService is ready to run.
+	 *
 	 * @param outputStream the OutputStream, this SendingService should write to.
 	 * @param toSendFrom   the BlockingQueue, that the Objects to send should be taken from
 	 */
@@ -49,4 +51,14 @@ public interface SendingService extends Runnable, SoftStoppable {
 	 * @param supplier the Supplier, that creates the ConnectionID
 	 */
 	void setConnectionIDSupplier(Supplier<String> supplier);
+
+	/**
+	 * This method returns whether or not this SendingService is setup or not.
+	 *
+	 * If it is setup, it can successfully run. To set it up, call {@link #setup(OutputStream, BlockingQueue)}.
+	 *
+	 * @return true, if it was setup, else false
+	 * @see #setup(OutputStream, BlockingQueue)
+	 */
+	boolean isSetup();
 }

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultReceivingService.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultReceivingService.java
@@ -5,7 +5,7 @@ import com.github.thorbenkuck.netcom2.annotations.Asynchronous;
 import com.github.thorbenkuck.netcom2.annotations.Synchronized;
 import com.github.thorbenkuck.netcom2.exceptions.CommunicationNotSpecifiedException;
 import com.github.thorbenkuck.netcom2.exceptions.DeSerializationFailedException;
-import com.github.thorbenkuck.netcom2.exceptions.SetupError;
+import com.github.thorbenkuck.netcom2.exceptions.SetupListenerException;
 import com.github.thorbenkuck.netcom2.network.interfaces.DecryptionAdapter;
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
 import com.github.thorbenkuck.netcom2.network.interfaces.ReceivingService;
@@ -232,7 +232,7 @@ class DefaultReceivingService implements ReceivingService {
 				in = new Scanner(connection.getInputStream());
 			}
 		} catch (IOException e) {
-			throw new SetupError(e);
+			throw new SetupListenerException(e);
 		}
 	}
 

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingService.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingService.java
@@ -219,7 +219,8 @@ class DefaultSendingService implements SendingService {
 	 */
 	@Override
 	public void setConnectionIDSupplier(Supplier<String> supplier) {
-		NetCom2Utils.parameterNotNull(supplier, supplier.get());
+		NetCom2Utils.parameterNotNull(supplier);
+		NetCom2Utils.parameterNotNull(supplier.get());
 		this.connectionID = supplier;
 	}
 

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingService.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingService.java
@@ -2,6 +2,7 @@ package com.github.thorbenkuck.netcom2.network.shared.clients;
 
 import com.github.thorbenkuck.netcom2.annotations.APILevel;
 import com.github.thorbenkuck.netcom2.exceptions.SerializationFailedException;
+import com.github.thorbenkuck.netcom2.exceptions.SetupListenerException;
 import com.github.thorbenkuck.netcom2.logging.NetComLogging;
 import com.github.thorbenkuck.netcom2.network.interfaces.EncryptionAdapter;
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
@@ -29,12 +30,11 @@ class DefaultSendingService implements SendingService {
 	private final EncryptionAdapter encryptionAdapter;
 	private final Logging logging = new NetComLogging();
 	private final Synchronize synchronize = new DefaultSynchronize(1);
-	private final List<Callback<Object>> callbacks = new ArrayList<>();
+	@APILevel protected final List<Callback<Object>> callbacks = new ArrayList<>();
 	private final int MAXIMUM_WAITING_TIME = 10;
 	private Supplier<String> connectionID = () -> "UNKNOWN-CONNECTION";
 	private PrintWriter printWriter;
-	@APILevel
-	private BlockingQueue<Object> toSend;
+	@APILevel protected BlockingQueue<Object> toSend;
 	private boolean running = false;
 	private boolean setup = false;
 	private int waitingTimeInSeconds = 2;
@@ -135,7 +135,7 @@ class DefaultSendingService implements SendingService {
 	@Override
 	public void run() {
 		if (! setup) {
-			throw new Error("[SendingService{" + connectionID.get() + "}] Setup required before run!");
+			throw new SetupListenerException("[SendingService{" + connectionID.get() + "}] Setup required before run!");
 		}
 		running = true;
 		containingThread = Thread.currentThread();
@@ -148,13 +148,13 @@ class DefaultSendingService implements SendingService {
 				// and the thread this runnable runs in may never terminate
 				// To ensure, that not every Sending Service is
 				// holding up the CPU, the waitingTimeInSeconds is
-				// decreased every time the DefaultSendingService
+				// increased every time the DefaultSendingService
 				// had waited.
 				final Object o = toSend.poll(waitingTimeInSeconds, TimeUnit.SECONDS);
 				// Take it first, then send it in another thread!
 				// this is done, to check, whether or not the object is null
 				// if it is null, no object was present.
-				// This means, the SendingService was shutDown.
+				// This means, the SendingService was shutDown or no object was present.
 				if (o != null) {
 					waitingTimeInSeconds = 2;
 					NetCom2Utils.runOnNetComThread(() -> send(o));
@@ -189,7 +189,7 @@ class DefaultSendingService implements SendingService {
 	 */
 	@Override
 	public void overrideSendingQueue(final BlockingQueue<Object> linkedBlockingQueue) {
-		NetCom2Utils.assertNotNull(linkedBlockingQueue);
+		NetCom2Utils.parameterNotNull(linkedBlockingQueue);
 		logging.warn("[SendingService{" + connectionID.get() + "}] Overriding the sending-hook should be used with caution!");
 		this.toSend = linkedBlockingQueue;
 	}
@@ -199,7 +199,7 @@ class DefaultSendingService implements SendingService {
 	 */
 	@Override
 	public void setup(final OutputStream outputStream, final BlockingQueue<Object> toSendFrom) {
-		NetCom2Utils.assertNotNull(outputStream, toSendFrom);
+		NetCom2Utils.parameterNotNull(outputStream, toSendFrom);
 		this.printWriter = new PrintWriter(outputStream);
 		this.toSend = toSendFrom;
 		setup = true;
@@ -230,6 +230,7 @@ class DefaultSendingService implements SendingService {
 	public void softStop() {
 		running = false;
 		if (containingThread != null) {
+			logging.trace("Interrupting the Thread: " + containingThread);
 			containingThread.interrupt();
 		}
 	}
@@ -240,5 +241,13 @@ class DefaultSendingService implements SendingService {
 	@Override
 	public boolean running() {
 		return running;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean isSetup() {
+		return setup;
 	}
 }

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingServiceTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingServiceTest.java
@@ -1,7 +1,10 @@
 package com.github.thorbenkuck.netcom2.network.shared.clients;
 
 import com.github.thorbenkuck.netcom2.exceptions.SerializationFailedException;
+import com.github.thorbenkuck.netcom2.exceptions.SetupListenerException;
+import com.github.thorbenkuck.netcom2.logging.NetComLogging;
 import com.github.thorbenkuck.netcom2.network.interfaces.EncryptionAdapter;
+import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
 import org.junit.Test;
 
 import java.io.OutputStream;
@@ -9,16 +12,29 @@ import java.util.HashSet;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+/**
+ * Some methods, like {@link com.github.thorbenkuck.netcom2.network.interfaces.SendingService#setup(OutputStream, BlockingQueue)}
+ * cannot be tested successfully, because they are blocking and sure as hell indeterminate.
+ * <p>
+ * So, if any test-case is missing, think about, whether this test-case is testable or not.
+ * <p>
+ * If i missed any, you may submit it to github.
+ */
 public class DefaultSendingServiceTest {
 
-	@Test(expected = Error.class)
+	private DefaultSendingService createSendingService() {
+		return new DefaultSendingService(new TestSerializationAdapter(), new HashSet<>(), new TestEncryptionAdapter());
+	}
+
+	@Test (expected = SetupListenerException.class)
 	public void runNotSetUp() throws Exception {
 		// Arrange
-		DefaultSendingService sendingService = new DefaultSendingService(new TestSerializationAdapter(), new HashSet<>(), new TestEncryptionAdapter());
-
+		DefaultSendingService sendingService = createSendingService();
 		// Act
 		sendingService.run();
 
@@ -29,10 +45,23 @@ public class DefaultSendingServiceTest {
 	@Test
 	public void addSendDoneCallback() throws Exception {
 		// Arrange
-		DefaultSendingService sendingService = new DefaultSendingService(new TestSerializationAdapter(), new HashSet<>(), new TestEncryptionAdapter());
+		DefaultSendingService sendingService = createSendingService();
 
 		// Act
-		sendingService.addSendDoneCallback(object -> {});
+		sendingService.addSendDoneCallback(object -> {
+		});
+
+		// Assert
+		assertEquals(1, sendingService.callbacks.size());
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void addSendDoneCallbackNull() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.addSendDoneCallback(null);
 
 		// Assert
 		fail();
@@ -41,8 +70,60 @@ public class DefaultSendingServiceTest {
 	@Test
 	public void overrideSendingQueue() throws Exception {
 		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+		BlockingQueue queue = sendingService.toSend;
 
 		// Act
+		sendingService.overrideSendingQueue(new LinkedBlockingQueue<>());
+
+		// Assert
+		assertNull(queue);
+		assertNotNull(sendingService.toSend);
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void overrideSendingQueueWithNull() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.overrideSendingQueue(null);
+
+		// Assert
+		fail();
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void setupMethodOutputStreamAndSendInterfaceNull() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.setup(null, null);
+
+		// Assert
+		fail();
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void setupMethodOutputStreamNull() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.setup(null, new LinkedBlockingQueue<>());
+
+		// Assert
+		fail();
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void setupMethodSendInterfaceNull() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.setup(mock(OutputStream.class), null);
 
 		// Assert
 		fail();
@@ -51,18 +132,54 @@ public class DefaultSendingServiceTest {
 	@Test
 	public void setupMethod() throws Exception {
 		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+		OutputStream outputStream = mock(OutputStream.class);
+		BlockingQueue<Object> sendInterface = new LinkedBlockingQueue<>();
+		BlockingQueue<Object> prev = sendingService.toSend;
 
 		// Act
+		sendingService.setup(outputStream, sendInterface);
 
 		// Assert
-		fail();
+		assertNull(prev);
+		assertNotNull(sendingService.toSend);
+		assertEquals(sendInterface, sendingService.toSend);
+		assertTrue(sendingService.isSetup());
 	}
 
 	@Test
 	public void started() throws Exception {
 		// Arrange
+//		DefaultSendingService sendingService = createSendingService();
 
 		// Act
+		// No act, should be non-empty and blocking by default
+//		Awaiting awaiting = sendingService.started();
+
+		// Assert
+		// TODO Test if the returned awaiting is empty. Can only be done, once this is merged
+//		assertFalse(Synchronize.isEmpty();
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void setConnectionIDSupplierNull() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.setConnectionIDSupplier(null);
+
+		// Assert
+		fail();
+	}
+
+	@Test (expected = IllegalArgumentException.class)
+	public void setConnectionIDSupplierNullGet() throws Exception {
+		// Arrange
+		DefaultSendingService sendingService = createSendingService();
+
+		// Act
+		sendingService.setConnectionIDSupplier(() -> null);
 
 		// Assert
 		fail();
@@ -71,31 +188,28 @@ public class DefaultSendingServiceTest {
 	@Test
 	public void setConnectionIDSupplier() throws Exception {
 		// Arrange
+		Logging logging = mock(Logging.class);
+		NetComLogging.setLogging(logging);
+		DefaultSendingService sendingService = createSendingService();
 
 		// Act
+		sendingService.setConnectionIDSupplier(() -> "LOCAL_TEST");
+		sendingService.overrideSendingQueue(new LinkedBlockingQueue<>());
 
 		// Assert
-		fail();
-	}
-
-	@Test
-	public void softStop() throws Exception {
-		// Arrange
-
-		// Act
-
-		// Assert
-		fail();
+		verify(logging).warn(contains("LOCAL_TEST"));
 	}
 
 	@Test
 	public void running() throws Exception {
 		// Arrange
+		DefaultSendingService sendingService = createSendingService();
 
 		// Act
+		boolean running = sendingService.running();
 
 		// Assert
-		fail();
+		assertFalse(running);
 	}
 
 	private class TestEncryptionAdapter implements EncryptionAdapter {

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingServiceTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/shared/clients/DefaultSendingServiceTest.java
@@ -1,15 +1,26 @@
 package com.github.thorbenkuck.netcom2.network.shared.clients;
 
+import com.github.thorbenkuck.netcom2.exceptions.SerializationFailedException;
+import com.github.thorbenkuck.netcom2.network.interfaces.EncryptionAdapter;
 import org.junit.Test;
 
+import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class DefaultSendingServiceTest {
-	@Test
-	public void run() throws Exception {
+
+	@Test(expected = Error.class)
+	public void runNotSetUp() throws Exception {
 		// Arrange
+		DefaultSendingService sendingService = new DefaultSendingService(new TestSerializationAdapter(), new HashSet<>(), new TestEncryptionAdapter());
 
 		// Act
+		sendingService.run();
 
 		// Assert
 		fail();
@@ -18,8 +29,10 @@ public class DefaultSendingServiceTest {
 	@Test
 	public void addSendDoneCallback() throws Exception {
 		// Arrange
+		DefaultSendingService sendingService = new DefaultSendingService(new TestSerializationAdapter(), new HashSet<>(), new TestEncryptionAdapter());
 
 		// Act
+		sendingService.addSendDoneCallback(object -> {});
 
 		// Assert
 		fail();
@@ -85,4 +98,25 @@ public class DefaultSendingServiceTest {
 		fail();
 	}
 
+	private class TestEncryptionAdapter implements EncryptionAdapter {
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public String get(final String s) {
+			return s;
+		}
+	}
+
+	private class TestSerializationAdapter implements SerializationAdapter<Object, String> {
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public String get(final Object o) throws SerializationFailedException {
+			return o.toString();
+		}
+	}
 }


### PR DESCRIPTION
I changed some things, that turned out to be wrong. For example: 

- threw raw Error 
- added missing method SendingService#isSetup 
- changed visibility of 2 attributes to protected (@APILevel)  

Some test-cases (like run, softStop, ...) cannot be tested. Those would require to change the production code to suit the test, which is not what we want.