### PR TITLE
#42 test remoteobjectregistrationimpl

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/exceptions/RemoteObjectInvalidMethodException.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/exceptions/RemoteObjectInvalidMethodException.java
@@ -1,0 +1,15 @@
+package com.github.thorbenkuck.netcom2.exceptions;
+
+public class RemoteObjectInvalidMethodException extends RemoteRequestException {
+	public RemoteObjectInvalidMethodException(String message) {
+		super(message);
+	}
+
+	public RemoteObjectInvalidMethodException(Throwable throwable) {
+		super(throwable);
+	}
+
+	public RemoteObjectInvalidMethodException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+}

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImpl.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImpl.java
@@ -288,6 +288,7 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 	 */
 	@Override
 	public void unregister(Class... identifier) {
+		NetCom2Utils.parameterNotNull(identifier);
 		for (Class clazz : identifier) {
 			_unregister(clazz);
 		}
@@ -322,6 +323,7 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 	@Override
 	public RemoteAccessCommunicationResponse run(final RemoteAccessCommunicationRequest request) {
 		NetCom2Utils.parameterNotNull(request);
+		NetCom2Utils.parameterNotNull(request.getMethodName(), request.getClazz(), request.getUuid());
 		final Object handlingObject;
 		synchronized (mapping) {
 			handlingObject = mapping.get(request.getClazz());

--- a/src/main/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImpl.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImpl.java
@@ -186,6 +186,13 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 		return true;
 	}
 
+	private void _unregister(Class clazz) {
+		logging.trace("Unregister " + clazz);
+		synchronized (mapping) {
+			mapping.remove(clazz);
+		}
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -271,7 +278,7 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 				logging.error("The Object " + object.getClass() + " is not assignable from " + clazz);
 				continue;
 			}
-			unregister(clazz);
+			_unregister(clazz);
 		}
 	}
 
@@ -281,10 +288,7 @@ class RemoteObjectRegistrationImpl implements RemoteObjectRegistration {
 	@Override
 	public void unregister(Class... identifier) {
 		for (Class clazz : identifier) {
-			logging.trace("Unregister " + clazz);
-			synchronized (mapping) {
-				mapping.remove(clazz);
-			}
+			_unregister(clazz);
 		}
 	}
 

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/NetCom2Utils.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/NetCom2Utils.java
@@ -115,6 +115,8 @@ public class NetCom2Utils {
 	 */
 	@APILevel
 	public static void parameterNotNull(final Object... objects) {
+		if(objects == null)
+			throw new IllegalArgumentException("Null is not a valid parameter!");
 		for (final Object object : objects) {
 			parameterNotNull(object);
 		}

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImplTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImplTest.java
@@ -1,42 +1,298 @@
 package com.github.thorbenkuck.netcom2.network.server;
 
+import com.github.thorbenkuck.netcom2.annotations.rmi.RegistrationOverrideProhibited;
+import com.github.thorbenkuck.netcom2.network.shared.comm.model.RemoteAccessCommunicationRequest;
+import com.github.thorbenkuck.netcom2.network.shared.comm.model.RemoteAccessCommunicationResponse;
 import org.junit.Test;
 
+import java.util.UUID;
+
+import static com.github.thorbenkuck.netcom2.TestUtils.UUID_SEED_1;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
 public class RemoteObjectRegistrationImplTest {
-	@Test
-	public void register() throws Exception {
+	@Test(expected=IllegalArgumentException.class)
+	public void registerInvalidArrayLength() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = new TestRemoteObject();
+		Class[] classes = new Class[0];
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classes);
+
+		//Assert
 	}
 
 	@Test
-	public void register1() throws Exception {
+	public void registerNotAssignable() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestUnassignableRemoteObject.class;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		String methodName = "aMethod";
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		verify(remoteObject, never()).aMethod();
 	}
 
 	@Test
-	public void hook() throws Exception {
+	public void registerOverrideProhibited() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRegistrationOverrideProhibitedRemoteObject.class;
+		String methodName = "aMethod";
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		verify(remoteObject, never()).aMethod();
 	}
 
 	@Test
-	public void unregister() throws Exception {
+	public void registerSuccess() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = "aMethod";
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		verify(remoteObject).aMethod();
 	}
 
 	@Test
-	public void unregister1() throws Exception {
+	public void hookInterface() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObjectWithInterface object = spy(new TestRemoteObjectWithInterface());
+		String methodName = "anInterfaceMethod";
+		Class<TestRemoteObjectWithInterface> clazz = TestRemoteObjectWithInterface.class;
+		Object[] parameters = null;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		RemoteAccessCommunicationRequest request = new RemoteAccessCommunicationRequest(methodName, clazz, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.hook(object);
+		remoteObjectRegistration.run(request);
+
+		//Assert
+		verify(object).anInterfaceMethod();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void hookNull() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.hook(null);
+
+		//Assert
 	}
 
 	@Test
-	public void unregister2() throws Exception {
+	public void unregisterObjectWithClassesSuccess() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject object = spy(new TestRemoteObject());
+		String methodName = "aMethod";
+		Class<TestRemoteObject> clazz = TestRemoteObject.class;
+		Object[] parameters = null;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		RemoteAccessCommunicationRequest request = new RemoteAccessCommunicationRequest(methodName, clazz, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(object, clazz);
+		remoteObjectRegistration.unregister(object, clazz);
+		remoteObjectRegistration.run(request);
+
+		//Assert
+		verify(object, never()).aMethod();
+	}
+
+	@Test
+	public void unregisterObjectWithClassesFail() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject object = spy(new TestRemoteObject());
+		String methodName = "aMethod";
+		Class<TestRemoteObject> clazz = TestRemoteObject.class;
+		Object[] parameters = null;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		RemoteAccessCommunicationRequest request = new RemoteAccessCommunicationRequest(methodName, clazz, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(object, clazz);
+		remoteObjectRegistration.unregister(object, AnInterface.class);
+		remoteObjectRegistration.run(request);
+
+		//Assert
+		verify(object).aMethod();
+	}
+
+	@Test
+	public void unregisterNoObjectOnlyClasses() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObjectWithInterface object = spy(new TestRemoteObjectWithInterface());
+		String methodName = "anInterfaceMethod";
+		Class<TestRemoteObjectWithInterface> clazz = TestRemoteObjectWithInterface.class;
+		Object[] parameters = null;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		RemoteAccessCommunicationRequest request = new RemoteAccessCommunicationRequest(methodName, clazz, uuid, parameters);
+		RemoteAccessCommunicationRequest request2 = new RemoteAccessCommunicationRequest(methodName, AnInterface.class, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.hook(object);
+		remoteObjectRegistration.unregister(clazz, AnInterface.class);
+		remoteObjectRegistration.run(request);
+		remoteObjectRegistration.run(request2);
+
+		//Assert
+		verify(object, never()).anInterfaceMethod();
 	}
 
 	@Test
 	public void unhook() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObjectWithInterface object = spy(new TestRemoteObjectWithInterface());
+		String methodName = "anInterfaceMethod";
+		String methodName2 = "aMethod";
+		Class<TestRemoteObjectWithInterface> clazz = TestRemoteObjectWithInterface.class;
+		Object[] parameters = null;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		RemoteAccessCommunicationRequest request = new RemoteAccessCommunicationRequest(methodName, clazz, uuid, parameters);
+		RemoteAccessCommunicationRequest request2 = new RemoteAccessCommunicationRequest(methodName2, clazz, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.hook(object);
+		remoteObjectRegistration.unhook(object);
+		remoteObjectRegistration.run(request);
+		remoteObjectRegistration.run(request2);
+
+		//Assert
+		verify(object, never()).anInterfaceMethod();
+		verify(object, never()).aMethod();
 	}
 
 	@Test
 	public void clear() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = "aMethod";
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.clear();
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		verify(remoteObject, never()).aMethod();
 	}
 
 	@Test
-	public void run() throws Exception {
+	public void runExistingMethod() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = "aMethod";
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		RemoteAccessCommunicationResponse response = remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		verify(remoteObject).aMethod();
+		assertNotNull(response);
+		assertNull(response.getResult());
+		assertEquals(uuid, response.getUuid());
+		assertNull(response.getThrownThrowable());
+	}
+
+	@Test
+	public void runNonExistentMethod() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = "aNonExistentMethod";
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		RemoteAccessCommunicationResponse response = remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		verify(remoteObject, never()).aMethod();
+		assertNotNull(response);
+		assertNull(response.getResult());
+		assertEquals(uuid, response.getUuid());
+		assertNotNull(response.getThrownThrowable());
+	}
+
+	private class TestRemoteObject {
+
+		public void aMethod() {}
+
+	}
+
+	private class TestRemoteObjectWithInterface implements AnInterface {
+
+		public void aMethod() {}
+
+		@Override
+		public void anInterfaceMethod() {
+
+		}
+	}
+
+	private class TestUnassignableRemoteObject {
+
+	}
+
+	@RegistrationOverrideProhibited
+	private class TestRegistrationOverrideProhibitedRemoteObject {
+
+	}
+
+	private interface AnInterface {
+
+		void anInterfaceMethod();
+
 	}
 
 }

--- a/src/test/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImplTest.java
+++ b/src/test/java/com/github/thorbenkuck/netcom2/network/server/RemoteObjectRegistrationImplTest.java
@@ -26,6 +26,7 @@ public class RemoteObjectRegistrationImplTest {
 		remoteObjectRegistration.register(remoteObject, classes);
 
 		//Assert
+		fail();
 	}
 
 	@Test
@@ -113,6 +114,7 @@ public class RemoteObjectRegistrationImplTest {
 		remoteObjectRegistration.hook(null);
 
 		//Assert
+		fail();
 	}
 
 	@Test
@@ -177,6 +179,66 @@ public class RemoteObjectRegistrationImplTest {
 		verify(object, never()).anInterfaceMethod();
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void unregisterNullClassArray() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.unregister((Class[]) null);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unregisterNullObject() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.unregister((Object) null);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unregisterNullObjectAndClassArray() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.unregister(null, (Class[]) null);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unregisterNullObjectWithClassArray() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.unregister((Object) null, TestRemoteObject.class);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unregisterNullClassArrayWithObject() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.unregister(new TestRemoteObject(), (Class[]) null);
+
+		//Assert
+		fail();
+	}
+
 	@Test
 	public void unhook() throws Exception {
 		//Arrange
@@ -199,6 +261,18 @@ public class RemoteObjectRegistrationImplTest {
 		//Assert
 		verify(object, never()).anInterfaceMethod();
 		verify(object, never()).aMethod();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unhookNull() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.unhook(null);
+
+		//Assert
+		fail();
 	}
 
 	@Test
@@ -315,6 +389,74 @@ public class RemoteObjectRegistrationImplTest {
 		assertEquals(uuid, response.getUuid());
 		assertNotNull(response.getThrownThrowable());
 		assertThat(response.getThrownThrowable(), instanceOf(RemoteObjectInvalidMethodException.class));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void runNullRequest() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+
+		//Act
+		remoteObjectRegistration.run(null);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void runNullMethod() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = null;
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void runNullClass() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = "aMethod";
+		UUID uuid = UUID.fromString(UUID_SEED_1);
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, null, uuid, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		fail();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void runNullUuid() throws Exception {
+		//Arrange
+		RemoteObjectRegistrationImpl remoteObjectRegistration = new RemoteObjectRegistrationImpl();
+		TestRemoteObject remoteObject = spy(new TestRemoteObject());
+		Class<?> classToAssign = TestRemoteObject.class;
+		String methodName = "aMethod";
+		Object[] parameters = null;
+		RemoteAccessCommunicationRequest communicationRequest = new RemoteAccessCommunicationRequest(methodName, classToAssign, null, parameters);
+
+		//Act
+		remoteObjectRegistration.register(remoteObject, classToAssign);
+		remoteObjectRegistration.run(communicationRequest);
+
+		//Assert
+		fail();
 	}
 
 	private class TestRemoteObject {


### PR DESCRIPTION
Added test cases, fixed behaviour of #run method.

The run method now throws a suitable exception if no method corresponding to the request could be found.
A bug regarding #unregister was fixed as well, it used to not unregister the specified class/object.