### PR TITLE
Add JavaDoc for pipeline and utility packages

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/CanBeRegistered.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/CanBeRegistered.java
@@ -17,6 +17,9 @@ import com.github.thorbenkuck.netcom2.network.shared.comm.OnReceiveTriple;
  * <li>{@link OnReceive}</li>
  * <li>{@link OnReceiveTriple}</li>
  * </ul>
+ *
+ * @since 1.0
+ * @version 1.0
  */
 public interface CanBeRegistered {
 

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/EmptyReceivePipelineCondition.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/EmptyReceivePipelineCondition.java
@@ -10,6 +10,9 @@ import java.util.function.Predicate;
  * This Class is an NullObject, used to ensure null are not necessary within the {@link ReceivePipelineCondition}
  *
  * @param <T> The generic Type the should be mimicked
+ *
+ * @since 1.0
+ * @version 1.0
  */
 @APILevel
 class EmptyReceivePipelineCondition<T> implements ReceivePipelineCondition<T> {

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceivePredicateWrapper.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceivePredicateWrapper.java
@@ -15,6 +15,9 @@ import java.util.function.BiPredicate;
  * This class is not meant for use outside of NetCom2. It is an internal component and only used by the {@link ReceivePipeline}
  *
  * @param <T> the Object, which will be received over the network and handled at either the ClientStartup or ServerStartup.
+ *
+ * @since 1.0
+ * @version 1.0
  */
 @APILevel
 class OnReceivePredicateWrapper<T> implements TriPredicate<Connection, Session, T> {
@@ -27,17 +30,26 @@ class OnReceivePredicateWrapper<T> implements TriPredicate<Connection, Session, 
 		this.biPredicate = biPredicate;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final boolean test(final Connection connection, final Session session, final T t) {
 		NetCom2Utils.parameterNotNull(session, t);
 		return biPredicate.test(session, t);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final int hashCode() {
 		return biPredicate.hashCode();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final boolean equals(final Object o) {
 		if(o == null) {
@@ -51,6 +63,9 @@ class OnReceivePredicateWrapper<T> implements TriPredicate<Connection, Session, 
 		return biPredicate.equals(o);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final String toString() {
 		return biPredicate.toString();

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceiveSinglePredicateWrapper.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceiveSinglePredicateWrapper.java
@@ -8,28 +8,52 @@ import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
 import java.util.function.Predicate;
 
+/**
+ * Wraps a Predicate into a TriPredicate.
+ * <p>
+ * This class is meant for NetCom2 internal use only.
+ *
+ * @param <T> The type
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 @APILevel
 class OnReceiveSinglePredicateWrapper<T> implements TriPredicate<Connection, Session, T> {
 
 	private final Predicate<Session> predicate;
 
+	/**
+	 * Creates a wrapper from the specified predicate.
+	 *
+	 * @param predicate The predicate to be wrapped
+	 */
 	@APILevel
 	OnReceiveSinglePredicateWrapper(final Predicate<Session> predicate) {
 		NetCom2Utils.assertNotNull(predicate);
 		this.predicate = predicate;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final boolean test(final Connection connection, final Session session, final T t) {
 		NetCom2Utils.parameterNotNull(session);
 		return predicate.test(session);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final int hashCode() {
 		return predicate.hashCode();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final boolean equals(final Object o) {
 		if(o == null) {
@@ -43,6 +67,9 @@ class OnReceiveSinglePredicateWrapper<T> implements TriPredicate<Connection, Ses
 		return predicate.equals(o);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final String toString() {
 		return predicate.toString();

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceiveSingleWrapper.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceiveSingleWrapper.java
@@ -7,43 +7,76 @@ import com.github.thorbenkuck.netcom2.network.shared.comm.OnReceiveSingle;
 import com.github.thorbenkuck.netcom2.network.shared.comm.OnReceiveTriple;
 import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
+/**
+ * Wraps an OnReceiveSingle into a OnReceiveTriple.
+ * <p>
+ * This class is meant for NetCom2 internal use only.
+ *
+ * @param <O> The type
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 @APILevel
 class OnReceiveSingleWrapper<O> implements OnReceiveTriple<O> {
 
 	private final OnReceiveSingle<O> onReceive;
 
+	/**
+	 * Creates a wrapper for the specified OnReceiveSingle.
+	 *
+	 * @param onReceive The OnReceiveSingle to be wrapped
+	 */
 	@APILevel
 	OnReceiveSingleWrapper(final OnReceiveSingle<O> onReceive) {
 		NetCom2Utils.assertNotNull(onReceive);
 		this.onReceive = onReceive;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void accept(final Connection connection, final Session session, final O o) {
 		NetCom2Utils.parameterNotNull(o);
 		onReceive.accept(o);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void onUnRegistration() {
 		onReceive.onUnRegistration();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void onRegistration() {
 		onReceive.onRegistration();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void onAddFailed() {
 		onReceive.onAddFailed();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final int hashCode() {
 		return onReceive.hashCode();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final boolean equals(final Object o) {
 		if (o == null) {
@@ -57,6 +90,9 @@ class OnReceiveSingleWrapper<O> implements OnReceiveTriple<O> {
 		return onReceive.equals(o);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final String toString() {
 		return onReceive.toString();

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceiveWrapper.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/OnReceiveWrapper.java
@@ -7,43 +7,76 @@ import com.github.thorbenkuck.netcom2.network.shared.comm.OnReceive;
 import com.github.thorbenkuck.netcom2.network.shared.comm.OnReceiveTriple;
 import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
+/**
+ * Wraps an OnReceive into a OnReceiveTriple.
+ * <p>
+ * This class is meant for NetCom2 internal use only.
+ *
+ * @param <O> The type
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 @APILevel
 class OnReceiveWrapper<O> implements OnReceiveTriple<O> {
 
 	private final OnReceive<O> onReceive;
 
+	/**
+	 * Creates a wrapper from the specified OnReceive.
+	 *
+	 * @param onReceive The OnReceive to wrap
+	 */
 	@APILevel
 	OnReceiveWrapper(final OnReceive<O> onReceive) {
 		NetCom2Utils.assertNotNull(onReceive);
 		this.onReceive = onReceive;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void accept(final Connection connection, final Session session, final O o) {
 		NetCom2Utils.parameterNotNull(session, o);
 		onReceive.accept(session, o);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void onUnRegistration() {
 		onReceive.onUnRegistration();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void onRegistration() {
 		onReceive.onRegistration();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void onAddFailed() {
 		onReceive.onAddFailed();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final int hashCode() {
 		return onReceive.hashCode();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final boolean equals(final Object o) {
 		if (o == null) {
@@ -57,6 +90,9 @@ class OnReceiveWrapper<O> implements OnReceiveTriple<O> {
 		return onReceive.equals(o);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final String toString() {
 		return onReceive.toString();

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/PipelineReceiver.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/PipelineReceiver.java
@@ -15,6 +15,9 @@ import java.util.Queue;
  * they are clustered.
  *
  * @param <T> The object, that is handled by the {@link OnReceiveTriple} and tested by the {@link TriPredicate}
+ *
+ * @since 1.0
+ * @version 1.0
  */
 @APILevel
 class PipelineReceiver<T> {
@@ -71,12 +74,29 @@ class PipelineReceiver<T> {
 		return onReceive.equals(that.onReceive);
 	}
 
+	/**
+	 * Adds a TriPredicate to the internal Queue.
+	 * <p>
+	 * This method is only meant for internal use.
+	 *
+	 * @param triPredicate The TriPredicate to add
+	 */
 	@APILevel
 	final void addTriPredicate(final TriPredicate<Connection, Session, T> triPredicate) {
 		NetCom2Utils.parameterNotNull(triPredicate);
 		predicates.add(triPredicate);
 	}
 
+	/**
+	 * Test all TriPredicates and return false early if one returns false.
+	 * <p>
+	 * This method is only meant for internal use.
+	 *
+	 * @param connection The connection to test with
+	 * @param session The session to test with
+	 * @param t The T to test with
+	 * @return false if one predicate returns false, true otherwise
+	 */
 	@APILevel
 	final boolean test(Connection connection, Session session, T t) {
 		NetCom2Utils.parameterNotNull(connection, session, t);
@@ -89,6 +109,13 @@ class PipelineReceiver<T> {
 		return true;
 	}
 
+	/**
+	 * Get the internal OnReceiveTriple instance.
+	 * <p>
+	 * This method is only meant for internal use.
+	 *
+	 * @return The OnReceiveTriple
+	 */
 	@APILevel
 	final OnReceiveTriple<T> getOnReceive() {
 		return onReceive;

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/QueuedReceivePipeline.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/QueuedReceivePipeline.java
@@ -17,6 +17,14 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 
+/**
+ * A queued ReceivePipeline implementation.
+ *
+ * @param <T> The type
+ *
+ * @version 1.0
+ * @since 1.0
+ */
 public class QueuedReceivePipeline<T> implements ReceivePipeline<T> {
 
 	private final Queue<PipelineReceiver<T>> core = new LinkedList<>();
@@ -29,11 +37,25 @@ public class QueuedReceivePipeline<T> implements ReceivePipeline<T> {
 	private boolean sealed = false;
 	private ReceivePipelineHandlerPolicy receivePipelineHandlerPolicy = ReceivePipelineHandlerPolicy.ALLOW_SINGLE;
 
+	/**
+	 * Create a queued ReceivePipeline for the specified class
+	 *
+	 * @param clazz The class
+	 */
 	public QueuedReceivePipeline(final Class<T> clazz) {
 		NetCom2Utils.parameterNotNull(clazz);
 		this.clazz = clazz;
 	}
 
+	/**
+	 * Tries to put the specified connection, session and S into the specified pipeline receiver.
+	 *
+	 * @param receiver The PipelineReceiver
+	 * @param connection The connection
+	 * @param session The session
+	 * @param s The S
+	 * @param <S> The type
+	 */
 	private <S> void run(PipelineReceiver<S> receiver, Connection connection, Session session, S s) {
 		OnReceiveTriple<S> onReceiveTriple = receiver.getOnReceive();
 		if (onReceiveTriple == null) {
@@ -53,10 +75,20 @@ public class QueuedReceivePipeline<T> implements ReceivePipeline<T> {
 		}
 	}
 
+	/**
+	 * Add a fail to the specified CanBeRegistered
+	 *
+	 * @param canBeRegistered The CanBeRegistered
+	 */
 	private void falseAdd(final CanBeRegistered canBeRegistered) {
 		canBeRegistered.onAddFailed();
 	}
 
+	/**
+	 * Execute the specified runnable (on the current thread) if the pipeline is open.
+	 *
+	 * @param runnable The runnable to execute
+	 */
 	private void ifOpen(final Runnable runnable) {
 		if (! closed) {
 			runnable.run();
@@ -458,12 +490,18 @@ public class QueuedReceivePipeline<T> implements ReceivePipeline<T> {
 		semaphore.release();
 	}
 
+	/**
+	 * Throws PipelineAccessException if pipeline is closed.
+	 */
 	protected void requiresOpen() {
 		if (closed) {
 			throw new PipelineAccessException("ReceivePipeline Closed!");
 		}
 	}
 
+	/**
+	 * Throws PipelineAccessException if pipeline is sealed.
+	 */
 	protected void requiredNotSealed() {
 		if (sealed) {
 			throw new PipelineAccessException("ReceivePipeline is sealed!");

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReceivePipelineCondition.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReceivePipelineCondition.java
@@ -5,13 +5,37 @@ import com.github.thorbenkuck.netcom2.network.shared.Session;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
+/**
+ * A condition for a ReceivePipeline, which adds the requirements to the underlying pipeline.
+ *
+ * @param <T> The type
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 public interface ReceivePipelineCondition<T> {
 
+	/**
+	 * Get an empty condition.
+	 *
+	 * @param <T> The type
+	 * @return An empty condition
+	 */
 	static <T> ReceivePipelineCondition<T> empty() {
 		return new EmptyReceivePipelineCondition<>();
 	}
 
+	/**
+	 * Adds a BiPredicate to the underlying receive pipeline.
+	 *
+	 * @param userPredicate The bi predicate to add
+	 */
 	void withRequirement(final BiPredicate<Session, T> userPredicate);
 
+	/**
+	 * Adds a predicate to the underlying receive pipeline.
+	 *
+	 * @param userPredicate The predicate
+	 */
 	void withRequirement(final Predicate<Session> userPredicate);
 }

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReceivePipelineConditionImpl.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReceivePipelineConditionImpl.java
@@ -7,23 +7,42 @@ import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
+/**
+ * A condition for receive pipelines.
+ * <p>
+ * This class is meant for NetCom2 internal use only.
+ *
+ * @param <T> The type
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 @APILevel
 class ReceivePipelineConditionImpl<T> implements ReceivePipelineCondition<T> {
 
 	private final PipelineReceiver<T> receiver;
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@APILevel
 	ReceivePipelineConditionImpl(final PipelineReceiver<T> receiver) {
 		NetCom2Utils.assertNotNull(receiver);
 		this.receiver = receiver;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void withRequirement(final BiPredicate<Session, T> userPredicate) {
 		NetCom2Utils.parameterNotNull(userPredicate);
 		receiver.addTriPredicate(new OnReceivePredicateWrapper<>(userPredicate));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public final void withRequirement(final Predicate<Session> userPredicate) {
 		NetCom2Utils.parameterNotNull(userPredicate);

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReceivePipelineHandlerPolicy.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReceivePipelineHandlerPolicy.java
@@ -6,6 +6,12 @@ import com.github.thorbenkuck.netcom2.interfaces.ReceivePipeline;
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
 import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
 
+/**
+ * This enumeration encapsulates methods to check capabilities of ReceivePipeline handlers in the respective modes.
+ *
+ * @version 1.0
+ * @since 1.0
+ */
 public enum ReceivePipelineHandlerPolicy {
 
 	NOT_ALLOWED {

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReflectionBasedObjectAnalyzer.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/ReflectionBasedObjectAnalyzer.java
@@ -2,7 +2,6 @@ package com.github.thorbenkuck.netcom2.pipeline;
 
 import com.github.thorbenkuck.netcom2.annotations.APILevel;
 import com.github.thorbenkuck.netcom2.annotations.ReceiveHandler;
-import com.github.thorbenkuck.netcom2.exceptions.PipelineAccessException;
 import com.github.thorbenkuck.netcom2.network.shared.Session;
 import com.github.thorbenkuck.netcom2.network.shared.clients.Connection;
 import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
@@ -11,14 +10,27 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+/**
+ * This class adds the capability of finding a method that takes a specific class as parameter.
+ * <p>
+ * This class is meant for NetCom2 internal use only.
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 @APILevel
 class ReflectionBasedObjectAnalyzer {
 
+	/**
+	 * Gets the method for the receive handler with the given class on the specified object.
+	 *
+	 * @param o The object to analyse
+	 * @param clazz The parameter type to look for
+	 * @param <T> The type of the parameter
+	 * @return An optional of the method, may be empty
+	 */
 	private <T> Optional<Method> getCorrespondingMethod(final Object o, final Class<T> clazz) {
 		for (Method method : o.getClass().getDeclaredMethods()) {
-//			if(!Modifier.isPrivate(method.getModifiers())) {
-//
-//			}
 			if (isAnnotationPresent(ReceiveHandler.class, method)) {
 				final ReceiveHandler receiveHandler = method.getAnnotation(ReceiveHandler.class);
 				if (receiveHandler.active() && containsOnlyAskedParameter(method, clazz)) {
@@ -30,10 +42,25 @@ class ReflectionBasedObjectAnalyzer {
 		return Optional.empty();
 	}
 
+	/**
+	 * Whether the method is annotated with the specified annotation or not.
+	 *
+	 * @param annotation The annotation to check for
+	 * @param method The method to analyse
+	 * @return True, if the annotation is present, false otherwise
+	 */
 	private boolean isAnnotationPresent(final Class<? extends Annotation> annotation, final Method method) {
 		return method.getAnnotation(annotation) != null;
 	}
 
+	/**
+	 * Find out if the specified method contains only the parameter specified, and it is not a Connection or Session.
+	 *
+	 * @param method The method to analyse
+	 * @param clazz The class to look for
+	 * @param <T> The type to look for
+	 * @return True if yes, false if no
+	 */
 	private <T> boolean containsOnlyAskedParameter(final Method method, final Class<T> clazz) {
 		boolean contains = false;
 		for (final Class clazzToCheck : method.getParameterTypes()) {
@@ -49,6 +76,16 @@ class ReflectionBasedObjectAnalyzer {
 		return contains;
 	}
 
+	/**
+	 * Get the method on the specified object that is responsible for the specified class.
+	 * <p>
+	 * This method is meant for internal use only.
+	 *
+	 * @param o The object to analyse
+	 * @param clazz The class to look for
+	 * @param <T> The type to look for
+	 * @return An optional of the responsible method, may be empty
+	 */
 	@APILevel
 	<T> Optional<Method> getResponsibleMethod(final Object o, final Class<T> clazz) {
 		NetCom2Utils.parameterNotNull(o, clazz);

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/Wrapper.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/Wrapper.java
@@ -13,7 +13,9 @@ import com.github.thorbenkuck.netcom2.utility.NetCom2Utils;
  * <p>
  * For most developers, this will not be necessary.
  * <p>
- * apiNote: Use {@link com.github.thorbenkuck.netcom2.utility.NetCom2Utils#wrap(OnReceive)} instead of this class. It encapsulates an Wrapper to free up resources
+ * @apiNote Use {@link com.github.thorbenkuck.netcom2.utility.NetCom2Utils#wrap(OnReceive)} instead of this class. It encapsulates an Wrapper to free up resources
+ * @since 1.0
+ * @version 1.0
  */
 public class Wrapper {
 

--- a/src/main/java/com/github/thorbenkuck/netcom2/pipeline/package-info.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/pipeline/package-info.java
@@ -1,0 +1,1 @@
+package com.github.thorbenkuck.netcom2.pipeline;

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/AsynchronousIterator.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/AsynchronousIterator.java
@@ -7,6 +7,15 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 
+/**
+ * This is an asynchronous Iterator. It works by making a copy of the specified collection,
+ * and only working on that.
+ *
+ * @param <T> The type of the elements of this iterator
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 public class AsynchronousIterator<T> implements Iterator<T> {
 
 	private final Queue<T> core;

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/NetCom2Utils.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/NetCom2Utils.java
@@ -19,6 +19,9 @@ import java.util.concurrent.*;
  * <p>
  * Since this class is used mainly internally, it should not be used outside of the internal project.
  * If you want to use it anyways, use it with care! This class is highly likely to be subject of change!
+ *
+ * @since 1.0
+ * @version 1.0
  */
 @APILevel
 public class NetCom2Utils {

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThread.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThread.java
@@ -2,44 +2,84 @@ package com.github.thorbenkuck.netcom2.utility;
 
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
 
+/**
+ * NetCom2 uses its own Threads such that developers can easily distinguish between NetCom2 Threads
+ * and application Threads.
+ *
+ * @since 1.0
+ * @version 1.0
+ */
 public class NetComThread extends Thread {
+
 
 	private NetComThreadContainer netComThreadContainer;
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread() {
 		setup();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread(Runnable runnable) {
 		super(runnable);
 		setup();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread(ThreadGroup group, Runnable target) {
 		super(group, target);
 		setup();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread(String name) {
 		super(name);
 		setup();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread(ThreadGroup group, String name) {
 		super(group, name);
 		setup();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread(Runnable target, String name) {
 		super(target, name);
 		setup();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public NetComThread(ThreadGroup group, Runnable target, String name) {
 		super(group, target, name);
 		setup();
 	}
 
+	/**
+	 *
+	 * Makes this Thread
+	 * <ul>
+	 *     <li><b>not</b> daemon</li>
+	 *     <li>priority 7</li>
+	 *     <li>named like a NetCom2 Thread</li>
+	 *     <li>log uncaught exceptions</li>
+	 * </ul>
+	 * The priority is such that it is higher than normal, but still not highest
+	 */
 	private void setup() {
 		setDaemon(false);
 		setPriority(7);
@@ -47,12 +87,23 @@ public class NetComThread extends Thread {
 		setUncaughtExceptionHandler((encounteredThread, throwable) -> Logging.unified().error("Unhandled Exception on NetComThread!", throwable));
 	}
 
+	/**
+	 *
+	 * {@inheritDoc}
+	 *
+	 */
 	@Override
 	public void run() {
 		super.run();
 		finished();
 	}
 
+
+	/**
+	 *
+	 * {@inheritDoc}
+	 *
+	 */
 	public String toString() {
 		if (! getName().equals(getThreadGroup().getName())) {
 			return getName() + "[" + getThreadGroup().getName() + "#" + getId() + "]";
@@ -61,6 +112,9 @@ public class NetComThread extends Thread {
 		}
 	}
 
+	/**
+	 * Removed this thread from its thread container, if it isn't null.
+	 */
 	public void finished() {
 		synchronized (this) {
 			if (netComThreadContainer != null) {
@@ -69,12 +123,22 @@ public class NetComThread extends Thread {
 		}
 	}
 
+	/**
+	 * Gets the internal thread container
+	 *
+	 * @return The thread container
+	 */
 	public NetComThreadContainer getNetComThreadContainer() {
 		synchronized (this) {
 			return netComThreadContainer;
 		}
 	}
 
+	/**
+	 * Sets the internal thread container to the specified one.
+	 *
+	 * @param netComThreadContainer The new thread container
+	 */
 	void setNetComThreadContainer(NetComThreadContainer netComThreadContainer) {
 		NetCom2Utils.parameterNotNull(netComThreadContainer);
 		synchronized (this) {

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThreadContainer.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThreadContainer.java
@@ -4,11 +4,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+/**
+ * A container for threads that grants the ability to get notified about finishing threads.
+ *
+ * @version 1.0
+ * @since 1.0
+ */
 public class NetComThreadContainer {
 
 	private final List<Thread> netComThreads = new ArrayList<>();
 	private final List<Consumer<Thread>> threadFinishedConsumers = new ArrayList<>();
 
+	/**
+	 * Notifies all consumers about the specified thread.
+	 *
+	 * @param thread The finished thread
+	 */
 	private void notifyAbout(Thread thread) {
 		NetCom2Utils.parameterNotNull(thread);
 		final List<Consumer<Thread>> consumerCopy;
@@ -19,6 +30,11 @@ public class NetComThreadContainer {
 		consumerCopy.forEach(consumer -> consumer.accept(thread));
 	}
 
+	/**
+	 * Add a thread to the thread container
+	 *
+	 * @param thread The thread to add
+	 */
 	public void addThread(Thread thread) {
 		NetCom2Utils.parameterNotNull(thread);
 		synchronized (netComThreads) {
@@ -26,6 +42,11 @@ public class NetComThreadContainer {
 		}
 	}
 
+	/**
+	 * Removes the specified thread and notifies the listeners
+	 *
+	 * @param thread The thread to remove
+	 */
 	public void removeThread(Thread thread) {
 		NetCom2Utils.parameterNotNull(thread);
 		synchronized (netComThreads) {
@@ -35,6 +56,11 @@ public class NetComThreadContainer {
 		notifyAbout(thread);
 	}
 
+	/**
+	 * Adds a listener for finished threads.
+	 *
+	 * @param consumer The listener to add
+	 */
 	public void addThreadFinishedConsumer(Consumer<Thread> consumer) {
 		NetCom2Utils.parameterNotNull(consumer);
 		synchronized (threadFinishedConsumers) {

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThreadFactory.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThreadFactory.java
@@ -6,6 +6,16 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+
+/**
+ * This ThreadFactory is primarily used to give to ExecutorServices in order to generate NetCom2's own Threads.
+ * <p>
+ * It allows to change whether newly spawned Threads should be daemon or not.
+ *
+ * @version 1.0
+ * @since 1.0
+ *
+ */
 public class NetComThreadFactory implements ThreadFactory {
 
 	static final String NET_COM_THREAD_NAME = "NetComThread";
@@ -14,12 +24,17 @@ public class NetComThreadFactory implements ThreadFactory {
 	// Check whether or not the Thread-Group helps
 	// or hinders the NetComThread (thread-safety)
 	private final NetComThreadGroup threadGroup = new NetComThreadGroup(Thread.currentThread().getThreadGroup(), "NetCom2ThreadGroup");
-	private AtomicBoolean daemon = new AtomicBoolean(true);
+	private final AtomicBoolean daemon = new AtomicBoolean(true);
 
 	NetComThreadFactory() {
 		logging.debug("Instantiated new NetComThreadFactory");
 	}
 
+	/**
+	 *
+	 * {@inheritDoc}
+	 *
+	 */
 	@Override
 	public Thread newThread(Runnable r) {
 		NetCom2Utils.parameterNotNull(r);
@@ -33,11 +48,21 @@ public class NetComThreadFactory implements ThreadFactory {
 		return thread;
 	}
 
+	/**
+	 * Add the specified Consumer to the internal ThreadContainer, if it isn't null.
+	 *
+	 * @param threadConsumer The Consumer to add
+	 */
 	public void onThreadFinished(Consumer<Thread> threadConsumer) {
 		NetCom2Utils.parameterNotNull(threadConsumer);
 		threadContainer.addThreadFinishedConsumer(threadConsumer);
 	}
 
+	/**
+	 * Sets whether newly spawned Thread instances should be daemon or not.
+	 *
+	 * @param daemon The daemon state
+	 */
 	public void setDaemon(boolean daemon) {
 		logging.debug("Setting daemon state of all Threads to: " + daemon);
 		this.daemon.set(daemon);

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThreadGroup.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/NetComThreadGroup.java
@@ -2,6 +2,14 @@ package com.github.thorbenkuck.netcom2.utility;
 
 import com.github.thorbenkuck.netcom2.network.interfaces.Logging;
 
+/**
+ * Represents a NetCom2 thread groups.
+ *
+ * It is currently debated if this class is really needed.
+ *
+ * @version 1.0
+ * @since 1.0
+ */
 public class NetComThreadGroup extends ThreadGroup {
 
 	private final Logging logging = Logging.unified();

--- a/src/main/java/com/github/thorbenkuck/netcom2/utility/package-info.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/utility/package-info.java
@@ -1,0 +1,1 @@
+package com.github.thorbenkuck.netcom2.utility;


### PR DESCRIPTION
The title kind of says it all, but I also made the following change:

In `ReceiveObjectHandlerWrapper#wrap`, I used `Optional#orElseThrow`
instead of manually checking if the value is present or not.
**It is to be discussed if this is better in any way.**

Additionally, I did **not** add any Tested annotations because I was unsure if those classes are actually tested.

Similarly, I did not put anything into the corresponding `package-info.java` files since I was unsure what to put in there.