### PR TITLE
Disconnection is now functioning again.

### DIFF
--- a/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/UDPConnectionFactory.java
+++ b/src/main/java/com/github/thorbenkuck/netcom2/network/shared/clients/UDPConnectionFactory.java
@@ -36,10 +36,8 @@ class UDPConnectionFactory implements ConnectionFactory {
 	 * @return a {@link ReceivingService}, usable by a {@link Connection}.
 	 */
 	private ReceivingService getReceivingService(final Client client) {
-		final ReceivingService receivingService = new DefaultReceivingService(client.getCommunicationRegistration(),
+		return new DefaultReceivingService(client.getCommunicationRegistration(),
 				client::getMainDeSerializationAdapter, client::getFallBackDeSerialization, client::getDecryptionAdapter);
-		receivingService.onDisconnect(client::disconnect);
-		return receivingService;
 
 	}
 
@@ -119,6 +117,7 @@ class UDPConnectionFactory implements ConnectionFactory {
 			try {
 				session.acquire();
 				connection = getConnection(socket, session, sendingService, receivingService, key);
+				connection.addOnDisconnectedConsumer(current -> client.disconnect());
 			} catch (InterruptedException e) {
 				logging.error("Could not create Connection " + key + "!", e);
 				return null;


### PR DESCRIPTION
You may test this, by starting a RMIServer and an RMIClient, then shutdown the RMIServer. The RMIClient will schedule a reconnect afterwards.


## Checklist
    
- [X] I am not on the master
- [X] I am not on the dev branch (or my issue contains urgent)
- [X] All classes and interfaces I created have clear and concise JavaDoc
- [X] All classes and interfaces I **changed** have JavaDoc according to my changes
- [X] All classes are tested with respect to their implemented interfaces
- [X] The feature i created/the bug i fixed is tested as an ~~unit-test~~ integration-test

If your checklist does **not** look like the above, please keep working on your branch until it does.
    
**If it does not, your PR will be rejected!**

Please also link the issue this pull-request seeks to resolve.
    
---
    
## Description/summary

I changed the Disconnection detected callback from the <code>ReceivedListener</code> to the <code>AbstractConnection</code>. This means, the<code>AbstractConnection</code> handles the details over what to do, once the Connection is terminated and the <code>ReceivedListener</code> only informes the <code>AbstractConnection</code> about the disconnect.

The Callback is set automatically inside the <code>AbstractConnection#setup</code> method.

No test has been updated. This has been tested before inside of Integration-Tests, since this is not detectable through Unit-Tests. The test i used is the <code>RMIServer</code> and <code>RMIClient</code> test. Steps to reproduce:

1. Start RMIServer.
2. Start RMIClient.
3. Close RMIServer.

Result => RMIClient schedules a reconnect.
    
**No public interfaces are broken.**